### PR TITLE
Possible typo? input → output

### DIFF
--- a/public/docs/extensibility.jade
+++ b/public/docs/extensibility.jade
@@ -27,7 +27,7 @@ section#internal-architecture
 
        Interlock's compilation is built on pluggable functions.
 
-      Pluggable functions are like pure functions, taking inputs, delegating certain computations to other functions (often pluggables), and returning an input.  However, there are a few fundamental differences.
+      Pluggable functions are like pure functions, taking inputs, delegating certain computations to other functions (often pluggables), and returning an output.  However, there are a few fundamental differences.
 
       - Each function is wrapped in a `pluggable` call at its point of definition, and its dependencies are explicitly defined.
       - Pluggable functions expect a special `this` context when invoked.  This context is constructed for and passed into the top-level pluggable function (normally the `compile` pluggable).  The context is then made available to the top-level pluggable's dependencies, their dependencies, and so on.


### PR DESCRIPTION
Not sure if this is a typo or not, but "returning an input" seemed wrong to me.
